### PR TITLE
Fix an implicit conversion error from the latest clang

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -78,6 +78,7 @@
 #define CONFIG_STACK_CHECK
 #endif
 
+static double const INT64_MAX_PLUS_ONE_AS_DOUBLE = 9223372036854775808.0;
 
 /* dump object free */
 //#define DUMP_FREE
@@ -10738,7 +10739,7 @@ static int JS_ToInt64SatFree(JSContext *ctx, int64_t *pres, JSValue val)
             } else {
                 if (d < INT64_MIN)
                     *pres = INT64_MIN;
-                else if (d > INT64_MAX)
+                else if (d >= INT64_MAX_PLUS_ONE_AS_DOUBLE)
                     *pres = INT64_MAX;
                 else
                     *pres = (int64_t)d;
@@ -53844,7 +53845,7 @@ static JSValue js_atomics_wait(JSContext *ctx,
     }
     if (JS_ToFloat64(ctx, &d, argv[3]))
         return JS_EXCEPTION;
-    if (isnan(d) || d > INT64_MAX)
+    if (isnan(d) || d >= INT64_MAX_PLUS_ONE_AS_DOUBLE)
         timeout = INT64_MAX;
     else if (d < 0)
         timeout = 0;


### PR DESCRIPTION
    error: implicit conversion from 'long long' to 'double' changes
           value from 9223372036854775807 to 9223372036854775808
           [-Werror,-Wimplicit-const-int-float-conversion]
                    else if (d > INT64_MAX)
                               ~ ^~~~~~~~~